### PR TITLE
Implement name and service confirmation

### DIFF
--- a/controllers/clienteController.js
+++ b/controllers/clienteController.js
@@ -1,8 +1,8 @@
 const pool = require("../config/db");
 
 // Encontra ou cria um cliente no banco de dados.
-// Se o cliente existir, ele é retornado. Se não, um novo é criado.
-// Tenta usar profileName do Twilio, se disponível.
+// Se o cliente existir, ele é retornado. Se não, um novo é criado
+// utilizando o nome fornecido (geralmente vindo do WhatsApp).
 async function encontrarOuCriarCliente(telefone, profileName = "Cliente") {
   let client;
   try {
@@ -15,20 +15,6 @@ async function encontrarOuCriarCliente(telefone, profileName = "Cliente") {
     let cliente;
     if (rows.length > 0) {
       cliente = rows[0];
-      // Se o profileName vindo do Twilio for diferente do nome atual no DB
-      // e não for o nome padrão 'Cliente', atualiza o nome no DB.
-      if (
-        profileName &&
-        profileName !== "Cliente" &&
-        cliente.nome !== profileName
-      ) {
-        await client.query("UPDATE clientes SET nome = ? WHERE id = ?", [
-          profileName,
-          cliente.id,
-        ]);
-        cliente.nome = profileName; // Atualiza o objeto para o nome mais recente
-        console.log(`Nome do cliente atualizado para: ${profileName}`);
-      }
     } else {
       // Cliente não encontrado, cria um novo
       const nomeParaSalvar = profileName || "Cliente"; // Usa profileName se existir, senão 'Cliente'


### PR DESCRIPTION
## Summary
- ask user to confirm their WhatsApp profile name
- allow entering a new name if desired
- add confirmation step before finalizing an appointment
- keep simple client creation without auto-updating name

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6842fb0482808327b11456c3eb5309dd