### PR TITLE
Improve cancellation logic for specific appointment

### DIFF
--- a/controllers/gerenciamentoController.js
+++ b/controllers/gerenciamentoController.js
@@ -1,14 +1,14 @@
 // gerenciamentoController.js
 const pool = require("../config/db");
 
-async function cancelarAgendamento(agendamentoId) {
+async function cancelarAgendamento(agendamentoId, clienteId) {
   const connection = await pool.getConnection();
   try {
     await connection.beginTransaction();
 
     const [rows] = await connection.query(
-      'SELECT horario_id FROM agendamentos WHERE id = ? AND status = "ativo"',
-      [agendamentoId]
+      'SELECT horario_id FROM agendamentos WHERE id = ? AND cliente_id = ? AND status = "ativo"',
+      [agendamentoId, clienteId]
     );
 
     if (!rows.length) {
@@ -20,8 +20,8 @@ async function cancelarAgendamento(agendamentoId) {
     }
 
     await connection.query(
-      'UPDATE agendamentos SET status = "cancelado" WHERE id = ?',
-      [agendamentoId]
+      'UPDATE agendamentos SET status = "cancelado" WHERE id = ? AND cliente_id = ?',
+      [agendamentoId, clienteId]
     );
 
     await connection.query(

--- a/index.js
+++ b/index.js
@@ -94,10 +94,15 @@ app.post("/webhook", async (req, res) => {
             resposta =
               "Opção inválida. Responda com o número do agendamento para cancelar.";
           } else {
-            const agendamentoId = pendente.agendamentosAtivos[indice].id;
-            const resultado = await cancelarAgendamento(agendamentoId);
+            const agendamento = pendente.agendamentosAtivos[indice];
+            const resultado = await cancelarAgendamento(
+              agendamento.id,
+              pendente.clienteId
+            );
             resposta = resultado.success
-              ? "Agendamento cancelado com sucesso!"
+              ? `Agendamento de ${agendamento.servico} em ${formatarData(
+                  agendamento.dia_horario
+                )} cancelado com sucesso!`
               : resultado.message;
             agendamentosPendentes.delete(from);
           }


### PR DESCRIPTION
## Summary
- restrict cancellation queries to the requesting client
- send detailed confirmation of which appointment was cancelled

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684309ff856c8327b2950b616b76dafa