### PR TITLE
Allow booking future dates

### DIFF
--- a/utils/formatters.js
+++ b/utils/formatters.js
@@ -89,10 +89,26 @@ function encontrarHorarioProximo(horarioSolicitadoStr, horariosDisponiveis) {
   ).horario;
 }
 
+function separarDiasPorSemana(datas) {
+  const hoje = new Date();
+  const limite = new Date(hoje);
+  limite.setDate(hoje.getDate() + 6);
+  const diasSemana = [];
+  const diasFuturos = [];
+  for (const d of datas) {
+    const data = new Date(d);
+    if (isNaN(data.getTime())) continue;
+    if (data <= limite) diasSemana.push(d);
+    else diasFuturos.push(d);
+  }
+  return { diasSemana, diasFuturos };
+}
+
 module.exports = {
   formatarData,
   formatarHora,
   formatarDia,
   getDateFromWeekdayAndTime,
   encontrarHorarioProximo,
+  separarDiasPorSemana,
 };


### PR DESCRIPTION
## Summary
- show only current week's dates when listing appointment days
- add option to display future dates
- expose `separarDiasPorSemana` helper

## Testing
- `node -c index.js`
- `node -c utils/formatters.js`


------
https://chatgpt.com/codex/tasks/task_e_6843484113008327843bdcb00889a1d6