### PR TITLE
Fix past dates display and improve "more dates" prompts

### DIFF
--- a/controllers/gerenciamentoController.js
+++ b/controllers/gerenciamentoController.js
@@ -52,7 +52,7 @@ async function listarAgendamentosAtivos(clienteId) {
        JOIN agendamentos_servicos asv ON a.id = asv.agendamento_id
        JOIN servicos s ON asv.servico_id = s.id
        JOIN horarios_disponiveis h ON a.horario_id = h.id
-       WHERE a.cliente_id = ? AND a.status = 'ativo'`,
+       WHERE a.cliente_id = ? AND a.status = 'ativo' AND h.dia_horario >= NOW()`,
       [clienteId]
     );
     return rows;

--- a/index.js
+++ b/index.js
@@ -76,7 +76,7 @@ app.post("/webhook", async (req, res) => {
             pendente.diasFuturos = [];
             agendamentosPendentes.set(from, pendente);
             resposta =
-              "Datas futuras disponíveis:\n\n" +
+              "Mais datas disponíveis:\n\n" +
               pendente.diasDisponiveis
                 .map((d, i) => `${i + 1}. ${formatarDia(d)}`)
                 .join("\n") +
@@ -188,7 +188,7 @@ app.post("/webhook", async (req, res) => {
             diasSemana.map((d, i) => `${i + 1}. ${formatarDia(d)}`).join("\n");
 
           if (diasFuturos.length) {
-            resposta += "\n0. Ver mais datas";
+            resposta += "\n0 - Mais datas";
           }
 
           agendamentosPendentes.set(from, {
@@ -208,7 +208,7 @@ app.post("/webhook", async (req, res) => {
             pendente.diasFuturos = [];
             agendamentosPendentes.set(from, pendente);
             resposta =
-              "Datas futuras disponíveis:\n\n" +
+              "Mais datas disponíveis:\n\n" +
               pendente.diasDisponiveis
                 .map((d, i) => `${i + 1}. ${formatarDia(d)}`)
                 .join("\n") +
@@ -385,7 +385,7 @@ app.post("/webhook", async (req, res) => {
           diasSemana.map((d, i) => `${i + 1}. ${formatarDia(d)}`).join("\n");
 
         if (diasFuturos.length) {
-          resposta += "\n0. Ver mais datas";
+          resposta += "\n0 - Mais datas";
         }
 
         agendamento.confirmationStep = "escolher_dia";


### PR DESCRIPTION
## Summary
- filter past appointments from schedule listings
- reword more dates prompts to say "Mais datas"

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68434acde60083279e6085cf1f535ceb