### PR TITLE
Fix past dates showing

### DIFF
--- a/utils/formatters.js
+++ b/utils/formatters.js
@@ -91,13 +91,15 @@ function encontrarHorarioProximo(horarioSolicitadoStr, horariosDisponiveis) {
 
 function separarDiasPorSemana(datas) {
   const hoje = new Date();
-  const limite = new Date(hoje);
-  limite.setDate(hoje.getDate() + 6);
+  const inicioHoje = new Date(hoje.getFullYear(), hoje.getMonth(), hoje.getDate());
+  const limite = new Date(inicioHoje);
+  limite.setDate(inicioHoje.getDate() + 6);
   const diasSemana = [];
   const diasFuturos = [];
   for (const d of datas) {
     const data = new Date(d);
     if (isNaN(data.getTime())) continue;
+    if (data < inicioHoje) continue;
     if (data <= limite) diasSemana.push(d);
     else diasFuturos.push(d);
   }


### PR DESCRIPTION
## Summary
- ignore days before today in `separarDiasPorSemana`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68434c30a198832797901d941ee55321