### PR TITLE
Fix sábado scheduling

### DIFF
--- a/controllers/agendamentoController.js
+++ b/controllers/agendamentoController.js
@@ -7,7 +7,6 @@ async function buscarHorariosDisponiveis() {
        FROM horarios_disponiveis
        WHERE disponivel = TRUE
        AND dia_horario >= NOW()
-       AND DAYOFWEEK(dia_horario) BETWEEN 2 AND 7
        ORDER BY dia_horario`
     );
 


### PR DESCRIPTION
## Summary
- include saturday when listing available times

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6843507f61a48327b859c53d2f55757c